### PR TITLE
Add .gitignore for Mac VScode and Gitbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,60 @@
+### https://raw.github.com/github/gitignore/c4ed859434e4eb33c85ad8048fc907d470f8ae4b/Global/macOS.gitignore
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+### https://raw.github.com/github/gitignore/c4ed859434e4eb33c85ad8048fc907d470f8ae4b/Global/VisualStudioCode.gitignore
+
+.vscode/*
+#!.vscode/settings.json
+#!.vscode/tasks.json
+#!.vscode/launch.json
+#!.vscode/extensions.json
+
+
+### https://raw.github.com/github/gitignore/c4ed859434e4eb33c85ad8048fc907d470f8ae4b/GitBook.gitignore
+
+# Node rules:
+## Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
+.grunt
+
+## Dependency directory
+## Commenting this out is preferred by some people, see
+## https://docs.npmjs.com/misc/faq#should-i-check-my-node_modules-folder-into-git
+node_modules
+
+# Book build output
+_book
+
+# eBook build output
+*.epub
+*.mobi
+*.pdf
+
+


### PR DESCRIPTION
[Why] Set the .gitignore file to exclude unnecessary files in repository to use Mac, VScode, Gitbook.
[How] Create the .gitignore file using the tool gibo.
[Side effects] Unintended files may be excluded.